### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Swift Open Weather Map API
 Swift Open Weather Map API is a wrapper around [OpenWeatherAPI](http://openweathermap.org)
 
-[![Platform](https://img.shields.io/cocoapods/p/SwiftOpenWeatherMapAPI.svg?style=flat)](http://cocoadocs.org/docsets/SwiftOpenWeatherMapAPI) [![Cocoapods Compatible](https://img.shields.io/cocoapods/v/SwiftOpenWeatherMapAPI.svg?style=flat)](https://img.shields.io/cocoapods/v/SwiftOpenWeatherMapAPI.svg?style=flat)   [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![Platform](https://img.shields.io/cocoapods/p/SwiftOpenWeatherMapAPI.svg?style=flat)](http://cocoadocs.org/docsets/SwiftOpenWeatherMapAPI) [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/SwiftOpenWeatherMapAPI.svg?style=flat)](https://img.shields.io/cocoapods/v/SwiftOpenWeatherMapAPI.svg?style=flat)   [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 ## Requirements
 - iOS 8.0+ / Mac OS X 10.9+


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
